### PR TITLE
Multiple Handler Packages Configuration Option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,10 @@
     </reporting>
 
     <profiles>
+        <!-- Enable this profile to generate the config resource files. -->
+        <profile>
+            <id>schema-generation</id>
+        </profile>
         <profile>
             <id>release-sign-artifacts</id>
             <activation>

--- a/rpc-router/src/main/java/com/networknt/rpc/router/RpcRouterConfig.java
+++ b/rpc-router/src/main/java/com/networknt/rpc/router/RpcRouterConfig.java
@@ -1,24 +1,67 @@
 package com.networknt.rpc.router;
 
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.networknt.config.Config;
+import com.networknt.config.schema.*;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Created by steve on 19/02/17.
  */
+@ConfigSchema(configKey = "rpc-router", configName = "rpc-router", configDescription = "rpc-router configuration", outputFormats = {OutputFormat.JSON_SCHEMA, OutputFormat.YAML})
 public class RpcRouterConfig {
     public static final String CONFIG_NAME = "rpc-router";
-    public static final String HANDLER_PACKAGE = "handlerPackage";
+    public static final String HANDLER_PACKAGE = "handlerPackages";
     public static final String JSON_PATH = "jsonPath";
     public static final String FORM_PATH = "formPath";
-    public static final String RESOURCES_BASE_PATH = "resourcesBasePath";
     public static final String REGISTER_SERVICE = "registerService";
 
-    private String handlerPackage;
+    @ArrayField(
+            configFieldName = HANDLER_PACKAGE,
+            externalizedKeyName = HANDLER_PACKAGE,
+            externalized = true,
+            description = "The hybrid handler package names that is used for scanner during server startup. The more specific of package names, the faster to start\n" +
+                    "List the package prefixes for all handlers used. Leave an empty array to indicate wildcard (all packages)",
+            items = String.class
+    )
+    @JsonDeserialize(using = HandlerPackageDeserializer.class)
+    private List<String> handlerPackages;
+
+    @StringField(
+            configFieldName = JSON_PATH,
+            externalizedKeyName = JSON_PATH,
+            externalized = true,
+            description = "The JSON RPC API path"
+    )
     private String jsonPath;
+
+    @StringField(
+            configFieldName = FORM_PATH,
+            externalizedKeyName = FORM_PATH,
+            externalized = true,
+            description = "The form RPC API path"
+    )
     private String formPath;
-    private String resourcesBasePath;
+
+    @BooleanField(
+            configFieldName = REGISTER_SERVICE,
+            externalizedKeyName = REGISTER_SERVICE,
+            externalized = true,
+            description = "if we want to register all handlers as services to the Consul for client to discover"
+    )
     private boolean registerService;
 
     private Map<String, Object> mappedConfig;
@@ -51,61 +94,63 @@ public class RpcRouterConfig {
         setConfigData();
     }
 
-    public String getHandlerPackage() {
-        return handlerPackage;
-    }
-
-    public void setHandlerPackage(String handlerPackage) {
-        this.handlerPackage = handlerPackage;
+    public List<String> getHandlerPackages() {
+        return handlerPackages;
     }
 
     public String getJsonPath() {
         return jsonPath;
     }
 
-    public void setJsonPath(String jsonPath) {
-        this.jsonPath = jsonPath;
-    }
-
     public String getFormPath() {
         return formPath;
-    }
-
-    public void setFormPath(String formPath) {
-        this.formPath = formPath;
-    }
-
-    public String getResourcesBasePath() {
-        return resourcesBasePath;
-    }
-
-    public void setResourcesBasePath(String resourcesBasePath) {
-        this.resourcesBasePath = resourcesBasePath;
     }
 
     public boolean isRegisterService() {
         return registerService;
     }
 
-    public void setRegisterService(boolean registerService) {
-        this.registerService = registerService;
-    }
     public Map<String, Object> getMappedConfig() {
         return mappedConfig;
     }
 
     private void setConfigData() {
         if(getMappedConfig() != null) {
+
+            // Normally you can deserialize into itself by calling '...convertValue(getMappedConfig(), RpcRouterConfig.class)'
+            // but this would lead to an infinite loop since Jackson uses the no-args constructor which calls this method.
             Object object = getMappedConfig().get(HANDLER_PACKAGE);
-            if(object != null) handlerPackage = (String)object;
+            if(object != null) {
+                final var tempDeserializer = new HandlerPackageDeserializer();
+                final var tempModule = new SimpleModule();
+                tempModule.addDeserializer(List.class, tempDeserializer);
+                final var tempMapper = new ObjectMapper();
+                tempMapper.registerModule(tempModule);
+                this.handlerPackages = tempMapper.convertValue(object, new TypeReference<>() {});
+            }
             object = getMappedConfig().get(JSON_PATH);
             if(object != null) jsonPath = (String)object;
             object = getMappedConfig().get(FORM_PATH);
             if(object != null) formPath = (String)object;
-            object = getMappedConfig().get(RESOURCES_BASE_PATH);
-            if(object != null) resourcesBasePath = (String)object;
             object = getMappedConfig().get(REGISTER_SERVICE);
             if(object != null) registerService = Config.loadBooleanValue(REGISTER_SERVICE, object);
+        }
+    }
+
+    private static class HandlerPackageDeserializer extends JsonDeserializer<List<String>> {
+
+        @Override
+        public List<String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
+            final var mapper = (ObjectMapper) jsonParser.getCodec();
+            final JsonNode root = mapper.readTree(jsonParser);
+            if (root.isArray()) {
+                return mapper.convertValue(root, new TypeReference<>(){});
+            } else if (root.isTextual()) {
+                final String packages = mapper.convertValue(root, String.class);
+                return Arrays.stream(packages.split(",")).collect(Collectors.toList());
+            } else {
+                return List.of();
+            }
         }
     }
 

--- a/rpc-router/src/main/resources/config/rpc-router.yml
+++ b/rpc-router/src/main/resources/config/rpc-router.yml
@@ -2,7 +2,7 @@
 ---
 # The hybrid handler package name that is used for scanner during server startup. The more specific of package name, the faster to start
 # Leave it as with an empty string '' if the handler is scattered in multiple packages. or use the real package name like com.networknt
-handlerPackage: ${rpc-router.handlerPackage:''}
+handlerPackages: ${rpc-router.handlerPackages:[]}
 # The JSON RPC API path
 jsonPath: ${rpc-router.jsonPath:/api/json}
 # The form RPC API path

--- a/rpc-router/src/test/java/com/other/handler/OtherHybridHandler.java
+++ b/rpc-router/src/test/java/com/other/handler/OtherHybridHandler.java
@@ -1,0 +1,34 @@
+package com.other.handler;
+
+import com.networknt.rpc.HybridHandler;
+import com.networknt.rpc.router.ServiceHandler;
+import io.undertow.server.HttpServerExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+
+/**
+ * Created by steve on 20/02/17.
+ */
+@ServiceHandler(id="lightapi.net/rule/deleteRule/0.1.0")
+public class OtherHybridHandler implements HybridHandler {
+    static private final Logger logger = LoggerFactory.getLogger(OtherHybridHandler.class);
+
+    @Override
+    public ByteBuffer handle(HttpServerExchange exchange, Object input)  {
+        System.out.println("TestServiceHandler is called with " + input);
+        String message = "OK";
+        ByteBuffer buffer = ByteBuffer.allocateDirect(message.length());
+        try {
+            buffer.put(message.getBytes("US-ASCII"));
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Exception:" + e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+}

--- a/rpc-router/src/test/java/com/other/handler/OtherHybridHandler.java
+++ b/rpc-router/src/test/java/com/other/handler/OtherHybridHandler.java
@@ -3,30 +3,21 @@ package com.other.handler;
 import com.networknt.rpc.HybridHandler;
 import com.networknt.rpc.router.ServiceHandler;
 import io.undertow.server.HttpServerExchange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
- * Created by steve on 20/02/17.
+ * This test handler exists to test the multiple package handler configuration.
  */
 @ServiceHandler(id="lightapi.net/rule/deleteRule/0.1.0")
 public class OtherHybridHandler implements HybridHandler {
-    static private final Logger logger = LoggerFactory.getLogger(OtherHybridHandler.class);
 
     @Override
     public ByteBuffer handle(HttpServerExchange exchange, Object input)  {
-        System.out.println("TestServiceHandler is called with " + input);
+        System.out.println("OtherHybridHandler is called with " + input);
         String message = "OK";
         ByteBuffer buffer = ByteBuffer.allocateDirect(message.length());
-        try {
-            buffer.put(message.getBytes("US-ASCII"));
-        } catch (UnsupportedEncodingException e) {
-            logger.error("Exception:" + e.getMessage(), e);
-            throw new RuntimeException(e);
-        }
+        buffer.put(message.getBytes(StandardCharsets.US_ASCII));
         buffer.flip();
         return buffer;
     }

--- a/rpc-router/src/test/resources/config/rpc-router-empty.yml
+++ b/rpc-router/src/test/resources/config/rpc-router-empty.yml
@@ -1,5 +1,4 @@
 ---
-handlerPackage: ''
+handlerPackages: []
 jsonPath: /api/json
 formPath: /api/form
-resourcesBasePath: /

--- a/rpc-router/src/test/resources/config/rpc-router-false-package.yml
+++ b/rpc-router/src/test/resources/config/rpc-router-false-package.yml
@@ -1,6 +1,6 @@
 ---
-handlerPackage: com.networknt
+handlerPackages:
+  - com.networknt
 jsonPath: /api/json
 formPath: /api/form
-resourcesBasePath: /
 registerService: false

--- a/rpc-router/src/test/resources/config/rpc-router-multi-package.yml
+++ b/rpc-router/src/test/resources/config/rpc-router-multi-package.yml
@@ -1,0 +1,6 @@
+---
+handlerPackages:
+  - com.networknt
+jsonPath: /api/json
+formPath: /api/form
+registerService: true

--- a/rpc-router/src/test/resources/config/rpc-router-multi-package.yml
+++ b/rpc-router/src/test/resources/config/rpc-router-multi-package.yml
@@ -1,6 +1,7 @@
 ---
 handlerPackages:
   - com.networknt
+  - com.other.handler
 jsonPath: /api/json
 formPath: /api/form
 registerService: true

--- a/rpc-router/src/test/resources/config/rpc-router-true.yml
+++ b/rpc-router/src/test/resources/config/rpc-router-true.yml
@@ -1,6 +1,6 @@
 ---
-handlerPackage: com.networknt
+handlerPackages:
+  - com.networknt
 jsonPath: /api/json
 formPath: /api/form
-resourcesBasePath: /
 registerService: true

--- a/rpc-router/src/test/resources/config/values.yml
+++ b/rpc-router/src/test/resources/config/values.yml
@@ -2,7 +2,7 @@
 server.httpsPort: 49588
 
 # rpc-router.yml
-rpc-router.handlerPackage: com.networknt
+rpc-router.handlerPackages: com.networknt
 
 # hybrid-security.yml
 hybrid-security.keyResolver: JsonWebKeySet

--- a/rpc-security/src/test/resources/config/rpc-router-empty.yml
+++ b/rpc-security/src/test/resources/config/rpc-router-empty.yml
@@ -1,5 +1,5 @@
 ---
-handlerPackage: ''
+handlerPackages: []
 jsonPath: /api/json
 formPath: /api/form
 resourcesBasePath: /

--- a/rpc-security/src/test/resources/config/rpc-router-false-package.yml
+++ b/rpc-security/src/test/resources/config/rpc-router-false-package.yml
@@ -1,5 +1,5 @@
 ---
-handlerPackage: com.networknt
+handlerPackages: com.networknt
 jsonPath: /api/json
 formPath: /api/form
 resourcesBasePath: /

--- a/rpc-security/src/test/resources/config/rpc-router-true.yml
+++ b/rpc-security/src/test/resources/config/rpc-router-true.yml
@@ -1,5 +1,5 @@
 ---
-handlerPackage: com.networknt
+handlerPackages: com.networknt
 jsonPath: /api/json
 formPath: /api/form
 resourcesBasePath: /

--- a/rpc-security/src/test/resources/config/values.yml
+++ b/rpc-security/src/test/resources/config/values.yml
@@ -2,7 +2,7 @@
 server.httpsPort: 49588
 
 # rpc-router.yml
-rpc-router.handlerPackage: com.networknt
+rpc-router.handlerPackages: com.networknt
 
 # hybrid-security.yml
 hybrid-security.keyResolver: JsonWebKeySet


### PR DESCRIPTION
- Changed existing config property 'handlerPackage' to 'handlerPackages'
    - Type changed from string to list
    - Field can be defined in config file as an array or a comma delimited string array
- Added test case for multi-package option
- Removed unused 'resourcePath' config option
- Updated existing test configurations with new field values
- Added schema generation profile to project
- Updated RpcRouterConfig with schema generation annotations. 
- Changed deprecated whitelistPackages to acceptedPackages for handler scanning